### PR TITLE
Utils 2.0.0

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavaScriptLibraryMappings">
+    <file url="PROJECT" libraries="{@types/jest}" />
     <includedPredefinedLibrary name="Node.js Core" />
   </component>
 </project>

--- a/.idea/utils.iml
+++ b/.idea/utils.iml
@@ -8,5 +8,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="@types/jest" level="application" />
   </component>
 </module>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2021-10-01
+
+- Changed Node.js compatibility to use ver. 12 LTS
+- Changed dependencies to latest versions: `chalk`, `eventemitter3`, `export-files`, `pad`, `winston`, `jest`
 
 ## [1.1.1] - 2019-09-12
 

--- a/package.json
+++ b/package.json
@@ -6,17 +6,20 @@
   "scripts": {
     "test": "jest"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "repository": "https://github.com/resource-sentry/utils.git",
   "author": "Nicolas Siver",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^2.4.1",
-    "eventemitter3": "^3.1.0",
-    "export-files": "^2.1.1",
-    "pad": "^2.1.0",
-    "winston": "^3.0.0-rc5"
+    "chalk": "^4.1.2",
+    "eventemitter3": "^4.0.7",
+    "export-files": "^3.0.2",
+    "pad": "^3.2.0",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
-    "jest": "^24.9.0"
+    "jest": "^27.2.4"
   }
 }


### PR DESCRIPTION
- Changed Node.js compatibility to use ver. 12 LTS
- Changed dependencies to latest versions: `chalk`, `eventemitter3`, `export-files`, `pad`, `winston`, `jest`

Important: This branch doesn't include the version tag and version bump yet. It should be done later if PR will be approved, before the merge to the master and release.

And as a part of the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) OSS initiative, I wanted to ask you to add the label `hacktoberfest-accepted` if that PR will be accepted and merged.